### PR TITLE
GEODE-10489: Fix broken link in user guide pointing to version 1.16 documentation Found the issue trying to publish the 1.15.2 documentation

### DIFF
--- a/geode-book/config.yml
+++ b/geode-book/config.yml
@@ -21,17 +21,17 @@ public_host: localhost
 sections:
 - repository:
     name: geode-docs
-  directory: docs/guide/116
+  directory: docs/guide/115
   subnav_template: geode-subnav
 
 template_variables:
   product_name_long: Apache Geode
   product_name: Geode
   product_name_lowercase: geode
-  product_version: '1.16'
-  product_version_nodot: '116'
-  product_version_old_minor: '1.15'
-  product_version_geode: '1.16'
+  product_version: '1.15'
+  product_version_nodot: '115'
+  product_version_old_minor: '1.14'
+  product_version_geode: '1.15'
   min_java_version: '8'
   min_java_update: '121'
   support_url: http://geode.apache.org/community


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
GEODE-10489
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
yes
- [ ] Is your initial contribution a single, squashed commit?
yes
- [ ] Does `gradlew build` run cleanly?
yes
- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
